### PR TITLE
EN-548: Create plugin to airbrake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ember-cli-deploy-airbrake
+ember-cli-deploy-airbrake-sourcemap
 ==============================================================================
 
 > An ember-cli-deploy-plugin to upload javascript sourcemaps to [Airbrake](https://airbrake.io/).
@@ -13,24 +13,53 @@ Installation
 ------------------------------------------------------------------------------
 
 ```
-ember install ember-cli-deploy-airbrake
+ember install ember-cli-deploy-airbrake-sourcemap
 ```
 
+### Quick start
 
-Usage
+To get up and running quickly, do the following:
+
+- Ensure [ember-cli-deploy-build][2] is installed and configured
+
+Enable sourcemaps for all environments in `ember-cli-build.js`:
+
+```js
+/* jshint node:true */
+/* global require, module */
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function(defaults) {
+  let app = new EmberApp(defaults, {
+    // …
+    sourcemaps: {
+      enabled: true, // This allows sourcemaps to be generated in all environments
+      extensions: ['js']
+    }
+  });
+```
+
+Set Bugsnag options in your [`config/deploy.js`](http://ember-cli-deploy.com/docs/v1.0.x/configuration/). The following example assumes the values for the options will be set as environment variables on your server.
+
+```js
+  /* jshint node: true */
+
+  module.exports = function(deployTarget) {
+    // …
+
+    ENV['airbrake-sourcemap'] = {
+      projectId:  process.env.AIRBRAKE_PROJECT_ID,
+      projectKey: process.env.AIRBRAKE_PROJECT_KEY,
+      publicUrl: 'https://my.example.com'
+    };
+
+    // …
+
+    return ENV;
+  };
+```
+
 ------------------------------------------------------------------------------
-
-[Longer description of how to use the addon in apps.]
-
-
-Contributing
-------------------------------------------------------------------------------
-
-### Installation
-
-* `git clone <repository-url>`
-* `cd ember-cli-deploy-airbrake`
-* `npm install`
 
 ### Linting
 
@@ -56,5 +85,5 @@ License
 
 This project is licensed under the [MIT License](LICENSE.md).
 
-
+[2]: https://github.com/ember-cli-deploy/ember-cli-deploy-build "ember-cli-deploy-build"
 [10]: http://ember-cli-deploy.com/docs/v1.0.x/using-plugins/ "Plugin Documentation"

--- a/index.js
+++ b/index.js
@@ -9,5 +9,130 @@ const zlib = require('zlib');
 const BasePlugin = require('ember-cli-deploy-plugin');
 
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name,
+
+  createDeployPlugin: function (options) {
+    var DeployPlugin = BasePlugin.extend({
+      name: options.name,
+
+      defaultConfig: Object.freeze({
+        distDir: function (context) {
+          return context.distDir;
+        },
+        distFiles: function (context) {
+          return context.distFiles;
+        },
+        gzippedFiles: function (context) {
+          return context.gzippedFiles || [];
+        },
+        revisionKey: function (context) {
+          if (context.revisionData) {
+            return context.revisionData.revisionKey;
+          } else {
+            return process.env.SOURCE_VERSION || '';
+          }
+        },
+        environment: function (context) {
+          var airbrakeConfig = context.config["airbrake-sourcemap"].airbrakeConfig;
+          var buildConfig = context.config.build;
+          var environment = airbrakeConfig ? airbrakeConfig.environment : false;
+          return environment || buildConfig.environment || 'production';
+        },
+        additionalFiles: [],
+      }),
+      requiredConfig: Object.freeze(['projectId', 'projectKey']),
+
+      upload: function () {
+        var log = this.log.bind(this);
+        var distDir = this.readConfig('distDir');
+        var distFiles = this.readConfig('distFiles');
+        var projectId = this.readConfig('projectId');
+        var projectKey = this.readConfig('projectKey');
+        var revisionKey = this.readConfig('revisionKey');
+
+        log('Uploading sourcemaps to Rollbar', { verbose: true });
+
+        var publicUrl = this.readConfig('publicUrl');
+
+        var promiseArray = [];
+        var jsMapPairs = fetchJSMapPairs(distFiles, publicUrl, distDir);
+
+        for (var i = 0; i < jsMapPairs.length; i++) {
+          var mapFilePath = jsMapPairs[i].mapFile;
+          var jsFilePath = jsMapPairs[i].jsFile;
+
+          var formData = {
+            headers: {
+              'Authorization': `Bearer ${projectKey}`
+            },
+            name: jsFilePath,
+            file: this._readSourceMap(mapFilePath),
+            version: revisionKey,
+          };
+
+          log(`Uploading sourcemap to Airbrake: version=${revisionKey} name=${jsFilePath}`, { verbose: true });
+          var promise = request({
+            uri: `https://airbrake.io/api/v4/projects/${projectId}/sourcemaps`,
+            method: 'POST',
+            formData: formData
+          });
+          promiseArray.push(promise);
+        }
+
+        return RSVP.all(promiseArray)
+          .then(function () {
+            log('Finished uploading sourcemaps', { verbose: true });
+          });
+      },
+
+      _readSourceMap(mapFilePath) {
+        var relativeMapFilePath = mapFilePath.replace(this.readConfig('distDir') + '/', '');
+        if (this.readConfig('gzippedFiles').indexOf(relativeMapFilePath) !== -1) {
+          // When the source map is gzipped, we need to eagerly load it into a buffer
+          // so that the actual content length is known.
+          return {
+            value: zlib.unzipSync(fs.readFileSync(mapFilePath)),
+            options: {
+              filename: path.basename(mapFilePath),
+            }
+          };
+        } else {
+          return fs.createReadStream(mapFilePath);
+        }
+      }
+    });
+
+    return new DeployPlugin();
+  }
 };
+
+function fetchJSMapPairs(distFiles, publicUrl, distUrl) {
+  var jsFiles = indexByBaseFilename(fetchFilePaths(distFiles, '', 'js'));
+  return fetchFilePaths(distFiles, '', 'map').map(function (mapFile) {
+    return {
+      mapFile: distUrl + mapFile,
+      jsFile: publicUrl + jsFiles[getBaseFilename(mapFile)]
+    };
+  });
+}
+
+function indexByBaseFilename(files) {
+  return files.reduce(function (result, file) {
+    result[getBaseFilename(file)] = file;
+    return result;
+  }, {});
+}
+
+function getBaseFilename(file) {
+  return file.replace(/-[0-9a-f]+\.(js|map)$/, '');
+}
+
+function fetchFilePaths(distFiles, basePath, type) {
+  return distFiles.filter(function (filePath) {
+    return new RegExp('assets/.*\\.' + type + '$').test(filePath);
+  })
+    .map(function (filePath) {
+      return basePath + '/' + filePath;
+    });
+}
+

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
   name: require('./package').name,
 
   createDeployPlugin: function (options) {
+    console.log('entrou');
     var DeployPlugin = BasePlugin.extend({
       name: options.name,
 
@@ -43,6 +44,7 @@ module.exports = {
       requiredConfig: Object.freeze(['projectId', 'projectKey']),
 
       upload: function () {
+        console.log('entrou 2');
         var log = this.log.bind(this);
         var distDir = this.readConfig('distDir');
         var distFiles = this.readConfig('distFiles');
@@ -50,7 +52,7 @@ module.exports = {
         var projectKey = this.readConfig('projectKey');
         var revisionKey = this.readConfig('revisionKey');
 
-        log('Uploading sourcemaps to Rollbar', { verbose: true });
+        log('Uploading sourcemaps to Airbrake', { verbose: true });
 
         var publicUrl = this.readConfig('publicUrl');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-cli-deploy-airbrake",
+  "name": "ember-cli-deploy-airbrake-sourcemap",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
-    "ember-addon"
+    "ember-addon",
+    "ember-cli-deploy-plugin"
   ],
   "repository": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
-  "name": "ember-cli-deploy-airbrake",
+  "name": "ember-cli-deploy-airbrake-sourcemap",
   "version": "0.0.0",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon",
-    "ember-cli-deploy-plugin"
+    "ember-cli-deploy-plugin",
+    "airbrake",
+    "sourcemaps"
   ],
   "repository": "",
   "license": "MIT",


### PR DESCRIPTION
1) Task Link:
https://paycertify.atlassian.net/browse/EN-548

2) Back-out procedures:
- `git clone repo`
-  cd ember-cli-deploy-airbrake-sourcemap
- npm link
- cd .. 
- cd web_app
- npm link ember-cli-deploy-airbrake-sourcemap

3) Testing Procedures:
- ember deploy qa/production --verbose

so you must see some like this:

```
+- upload
|  |
|  +- airbrake-sourcemap
|    - Uploading sourcemaps to Airbrake
|    - Uploading sourcemap to Airbrake: version= name=https://qa-my.paycertify.com/assets/vendor-534fce18d47740d0e26096c68734a690.map file=tmp/deploy-dist/assets/vendor-534fce18d47740d0e26096c68734a690.map
|    - Uploading sourcemap to Airbrake: version= name=https://qa-my.paycertify.com/assets/web-app-12465c4e2bb0e4ec3979d1019af914cf.map file=tmp/deploy-dist/assets/web-app-12465c4e2bb0e4ec3979d1019af914cf.map
|    - body: {"id":2338745511573989851}
|    - body: {"id":2338745550723623388}
|    - Finished uploading sourcemaps
```

4) Deployment procedures: 
Nothing additional needed
